### PR TITLE
feat(resume): Added resume update from profile view

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,4 @@
+export const getFileExtension = (filename: string) => {
+  const seg = filename.split('.');
+  return `.${seg[seg.length - 1]}`;
+};

--- a/pages/api/resume/upload/index.ts
+++ b/pages/api/resume/upload/index.ts
@@ -40,9 +40,9 @@ handler.post(async (req, res) => {
     );
   const storage = firebase.storage();
 
-  const rootRef = firebase.storage().ref();
+  const rootRef = firebase.storage().ref('resumes');
   const fileRef = rootRef.child(req.body.fileName);
-  const snapshot = await fileRef.put(req.file.buffer);
+  await fileRef.put(req.file.buffer);
   res.end();
 });
 

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -11,6 +11,7 @@ import schools from '../public/schools.json';
 import majors from '../public/majors.json';
 import { hackPortalConfig, formInitialValues } from '../hackportal.config';
 import DisplayQuestion from '../components/DisplayQuestion';
+import { getFileExtension } from '../lib/util';
 
 /**
  * The registration page.
@@ -75,24 +76,12 @@ export default function Register() {
     checkRedirect();
   }, [user]);
 
-  const getExtension = (filename: string) => {
-    for (let i = filename.length - 1; i >= 0; i--) {
-      if (filename.charAt(i) == '.') return filename.substring(i, filename.length);
-    }
-    return '';
-  };
-
   const handleSubmit = async (registrationData) => {
     try {
       if (resumeFile) {
         const formData = new FormData();
         formData.append('resume', resumeFile);
-        formData.append(
-          'fileName',
-          `resume_${registrationData.user.firstName}_${
-            registrationData.user.lastName
-          }${getExtension(resumeFile.name)}`,
-        );
+        formData.append('fileName', `${user.id}${getFileExtension(resumeFile.name)}`);
         await fetch('/api/resume/upload', {
           method: 'post',
           body: formData,


### PR DESCRIPTION
- added ability to update resume from the profile view
- modified resume naming scheme to use the user's auth stub
- modified resume upload folder to "/resumes"
- refactored file extension parser to be, well, you know, not absolute garbage
- extracted file extension to /lib/util.ts, a new utilities source file that contributors will hopefully start taking advantage of

closes #164