### PR TITLE
fix(next-pwa): Next-PWA Runtime and Buildtime Error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,17 +1,18 @@
-const withPWA = require('next-pwa');
 const runtimeCaching = require('next-pwa/cache');
 const withFonts = require('next-fonts');
+
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  runtimeCaching,
+  disable: !process.env.ENABLE_PWA && process.env.NODE_ENV === 'development',
+});
 
 (module.exports = withPWA({
   reactStrictMode: true,
   images: {
     domains: ['lh3.googleusercontent.com', 'firebasestorage.googleapis.com'],
   },
-  pwa: {
-    dest: 'public',
-    runtimeCaching,
-    disable: !process.env.ENABLE_PWA && process.env.NODE_ENV === 'development',
-  },
+
   webpack(config, options) {
     config.module.rules.push({
       test: /\.md$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "next": "^12.1.0",
         "next-connect": "^0.11.0",
         "next-fonts": "^1.5.1",
-        "next-pwa": "^5.2.24",
+        "next-pwa": "^5.6.0",
         "notion-client": "^6.12.9",
         "qrcode": "^1.4.4",
         "raw-loader": "^4.0.2",
@@ -12246,9 +12246,9 @@
       }
     },
     "node_modules/next-pwa": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.5.5.tgz",
-      "integrity": "sha512-EdheDzxr3V7piAeW2qAeH0uJW5iouSt7s/Fzz6xuvkmRPgbyqQeRY/3ZOWbhfgbPBuzGjdbBWzVurWJPH8bY5w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.6.0.tgz",
+      "integrity": "sha512-XV8g8C6B7UmViXU8askMEYhWwQ4qc/XqJGnexbLV68hzKaGHZDMtHsm2TNxFcbR7+ypVuth/wwpiIlMwpRJJ5A==",
       "dependencies": {
         "babel-loader": "^8.2.5",
         "clean-webpack-plugin": "^4.0.0",
@@ -25615,9 +25615,9 @@
       }
     },
     "next-pwa": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.5.5.tgz",
-      "integrity": "sha512-EdheDzxr3V7piAeW2qAeH0uJW5iouSt7s/Fzz6xuvkmRPgbyqQeRY/3ZOWbhfgbPBuzGjdbBWzVurWJPH8bY5w==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.6.0.tgz",
+      "integrity": "sha512-XV8g8C6B7UmViXU8askMEYhWwQ4qc/XqJGnexbLV68hzKaGHZDMtHsm2TNxFcbR7+ypVuth/wwpiIlMwpRJJ5A==",
       "requires": {
         "babel-loader": "^8.2.5",
         "clean-webpack-plugin": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "next": "^12.1.0",
     "next-connect": "^0.11.0",
     "next-fonts": "^1.5.1",
-    "next-pwa": "^5.2.24",
+    "next-pwa": "^5.6.0",
     "notion-client": "^6.12.9",
     "qrcode": "^1.4.4",
     "raw-loader": "^4.0.2",


### PR DESCRIPTION
While running or building next-PWA throws out some errors like:

`Please check your GenerateSW plugin configuration:
[WebpackGenerateSW] 'reactStrictMode' property is not expected to be here. Did you mean property 'exclude'?`


warn  - Invalid next.config.js options detected: 
  - The root value has an unexpected property, pwa, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, crossOrigin, devIndicators, distDir, env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, future, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, staticPageGenerationTimeout, swcMinify, trailingSlash, typescript, useFileSystemPublicRoutes, webpack).
  
  **Upgrading the package to the latest and editing the next.config.js file fixes the issue.**