### PR TITLE
refactor: Use `Intl` API in schedule page

### DIFF
--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -171,7 +171,7 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
     // format list of speakers of event, leaving blank if no speakers
     const speakerFormatter = new Intl.ListFormat('default', { style: 'long', type: 'conjunction' });
     const speakerString =
-      speakersData?.length || 0 > 0 ? `Hosted by ${speakerFormatter.format(speakersData)}` : '';
+      speakersData?.length > 0 ? `Hosted by ${speakerFormatter.format(speakersData)}` : '';
     // format time range of event
     const timeFormatter = new Intl.DateTimeFormat('default', {
       hour: 'numeric',

--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -154,44 +154,30 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
     ),
   );
 
-  const changeEventData = (data) => {
-    const startDate = new firebase.firestore.Timestamp(data.startTimestamp._seconds, 0).toDate();
-    const endDate = new firebase.firestore.Timestamp(data.endTimestamp._seconds, 0).toDate();
-    //first match extracts day abbreviation
-    //second match extracts month abbreviation and the number day of the month
-    var dayString =
-      startDate.toString().match(/^[\w]{3}/)[0] +
-      ', ' +
-      startDate.toString().match(/^\w+ (\w{3} \d{1,2})/)[1];
+  const changeEventData = (data: ScheduleEvent) => {
+    const startDate = new Date(data.startDate);
+    const endDate = new Date(data.endDate);
 
-    const speakersData = data.speakers
-      ? data.speakers.filter((speaker) => speaker.length !== 0)
-      : undefined;
+    // format date of event
+    const dateFormatter = new Intl.DateTimeFormat('default', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    });
+    const dayString = dateFormatter.format(startDate);
 
-    var speakerString = '';
-    if (speakersData !== undefined && speakersData !== null && speakersData.length !== 0) {
-      if (speakersData.length == 2) {
-        speakerString = `Hosted by ${speakersData[0]} & ${speakersData[1]}`;
-      } else if (speakersData.length == 1) {
-        speakerString = `Hosted by ${speakersData[0]}`;
-      } else {
-        speakerString = 'Hosted by ';
-        for (var i = 0; i < speakersData.length; i++) {
-          if (i === speakersData.length - 1) {
-            speakerString += 'and ' + speakersData[i];
-          } else {
-            speakerString += speakersData[i] + ', ';
-          }
-        }
-      }
-    }
-    var timeString = `${(startDate.getHours() + 24) % 12 || 12}:${
-      startDate.getMinutes() < 10 ? '0' : ''
-    }${startDate.getMinutes()} ${startDate.getHours() < 12 ? 'AM' : 'PM'} - ${
-      (endDate.getHours() + 24) % 12 || 12
-    }:${endDate.getMinutes() < 10 ? '0' : ''}${endDate.getMinutes()} ${
-      endDate.getHours() < 12 ? 'AM' : 'PM'
-    }`;
+    const speakersData = data.speakers?.filter((speaker) => speaker.length !== 0);
+
+    // format list of speakers of event, leaving blank if no speakers
+    const speakerFormatter = new Intl.ListFormat('default', { style: 'long', type: 'conjunction' });
+    const speakerString =
+      speakersData?.length || 0 > 0 ? `Hosted by ${speakerFormatter.format(speakersData)}` : '';
+    // format time range of event
+    const timeFormatter = new Intl.DateTimeFormat('default', {
+      hour: 'numeric',
+      minute: 'numeric',
+    });
+    const timeString = timeFormatter.formatRange(startDate, endDate);
 
     //setting new event data based on event clicked
     setEventData({

--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { useState, useEffect } from 'react';
-import { GroupingState, IntegratedGrouping, ViewState } from '@devexpress/dx-react-scheduler';
+import {
+  AppointmentModel,
+  GroupingState,
+  IntegratedGrouping,
+  ViewState,
+} from '@devexpress/dx-react-scheduler';
 import {
   Scheduler,
   DayView,
@@ -154,7 +159,7 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
     ),
   );
 
-  const changeEventData = (data: ScheduleEvent) => {
+  const changeEventData = (data: AppointmentModel) => {
     const startDate = new Date(data.startDate);
     const endDate = new Date(data.endDate);
 
@@ -166,7 +171,7 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
     });
     const dayString = dateFormatter.format(startDate);
 
-    const speakersData = data.speakers?.filter((speaker) => speaker.length !== 0);
+    const speakersData = data.speakers?.filter((speaker: string[]) => speaker.length !== 0);
 
     // format list of speakers of event, leaving blank if no speakers
     const speakerFormatter = new Intl.ListFormat('default', { style: 'long', type: 'conjunction' });


### PR DESCRIPTION
I'm not sure why we were using custom formatting code for this, but [browser APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) provide built-in functions for all of the formatting on this page, namely [date and time formatting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) and [list formatting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) (i.e. `Hosted by A, B, and C`) with good [cross-browser support](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#browser_compatibility). This PR is small but reduces the code size (and also gives us automatic internationalization for free wrt formatting!).

**NOTE: this does slightly change the behavior of the component.** I meant for this to be a completely transparent change, but it does slightly alter how the event time is formatted. With these changes, if both times are in the same cycle (i.e. both AM or both PM), the time is given with the cycle label at the end `5:00 - 6:15 PM`; previously, the both times would include the cycle label, like `5:00 PM - 6:15 PM`. I actually think it looks better this way, so I didn't work to retain the behavior, but if this is desired, I can change it to match the old behavior. Obviously, if the two times are in separate cycles, both cycles are mentioned, like `10:45 AM - 3:15 PM`.