### PR TITLE
fix(calendar): Fix `Schedule` error when no events

### DIFF
--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -264,17 +264,9 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
                 <DateNavigator />
                 <TodayButton />
                 <GroupingState grouping={grouping} groupByDate={() => true} />
-                {
-                  // since tracks are computed from entries, only show grouping if there are any tracks
-                  uniqueTracks.size > 0 ? (
-                    <>
-                      <IntegratedGrouping />
-                      <GroupingPanel />
-                    </>
-                  ) : (
-                    <></>
-                  )
-                }
+                {/* since tracks are computed from entries, only show grouping if there are any tracks */}
+                {uniqueTracks.size > 0 ? <IntegratedGrouping /> : null}
+                {uniqueTracks.size > 0 ? <GroupingPanel /> : null}
               </Scheduler>
             </div>
           </Paper>

--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -272,9 +272,18 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
                 <Toolbar />
                 <DateNavigator />
                 <TodayButton />
-                <GroupingState grouping={grouping} groupByDate={() => true} />
-                <IntegratedGrouping />
-                <GroupingPanel />
+                {
+                  // since tracks are computed from entries, only show grouping if there are any tracks
+                  uniqueTracks.size > 0 ? (
+                    <>
+                      <GroupingState grouping={grouping} groupByDate={() => true} />
+                      <IntegratedGrouping />
+                      <GroupingPanel />
+                    </>
+                  ) : (
+                    <></>
+                  )
+                }
               </Scheduler>
             </div>
           </Paper>

--- a/pages/schedule/index.tsx
+++ b/pages/schedule/index.tsx
@@ -263,11 +263,11 @@ export default function Calendar(props: { scheduleCard: ScheduleEvent[] }) {
                 <Toolbar />
                 <DateNavigator />
                 <TodayButton />
+                <GroupingState grouping={grouping} groupByDate={() => true} />
                 {
                   // since tracks are computed from entries, only show grouping if there are any tracks
                   uniqueTracks.size > 0 ? (
                     <>
-                      <GroupingState grouping={grouping} groupByDate={() => true} />
                       <IntegratedGrouping />
                       <GroupingPanel />
                     </>


### PR DESCRIPTION
Since actual track instances (like "General", etc) are computed from the available appointments, the scheduler can't form groups if there are no appointments available because it never expects there to be no instances of a group when a group is specified. In reality, this is a bug in the scheduler component itself, and should be fixed a different way, perhaps by patching React Scheduler itself, but this will fix it for now by not attempting to render groupings when there are no groupings available.

fixes #191