### PR TITLE
refactor: Add schools and majors options to hack portal config object

### DIFF
--- a/components/registerComponents/RegistrationQuestion.tsx
+++ b/components/registerComponents/RegistrationQuestion.tsx
@@ -113,6 +113,11 @@ function Question(props) {
         ></Field>
         <datalist id={props.question.datalist}>
           <option value="" disabled selected></option>
+          {props.question.options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.title}
+            </option>
+          ))}
         </datalist>
         <ErrorMessage
           name={props.question.name}

--- a/hackportal.config.ts
+++ b/hackportal.config.ts
@@ -1,3 +1,6 @@
+import schools from './public/schools.json';
+import majors from './public/majors.json';
+
 export const hackPortalConfig: HackPortalConfig = {
   //registration fields are separated by question topics (general, school, hackathon experience, etc. )
   //each question topic is separated by question types(textInput, numberInput, dropdown, etc. )
@@ -149,6 +152,10 @@ export const hackPortalConfig: HackPortalConfig = {
             name: 'university',
             required: true,
             datalist: 'schools',
+            options: schools.map(({ university }) => ({
+              title: university,
+              value: university,
+            })),
             initialValue: '',
           },
           {
@@ -158,6 +165,10 @@ export const hackPortalConfig: HackPortalConfig = {
             name: 'major',
             required: true,
             datalist: 'majors',
+            options: majors.map(({ major }) => ({
+              title: major,
+              value: major,
+            })),
             initialValue: '',
           },
         ],
@@ -534,6 +545,10 @@ interface NumberInputQuestion extends RegistrationQuestion {
 
 interface datalistQuestion extends RegistrationQuestion {
   datalist: string;
+  options: Array<{
+    title: string;
+    value: string;
+  }>;
 }
 
 interface textAreaQuestion extends RegistrationQuestion {

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -42,28 +42,6 @@ export default function Register() {
   };
 
   useEffect(() => {
-    setTimeout(() => {
-      //load json data into dropdown list for universities and majors
-      if (document.getElementById('schools') !== null) {
-        for (let school of schools) {
-          let option = document.createElement('option');
-          option.text = school['university'];
-          option.value = school['university'];
-          let select = document.getElementById('schools');
-          select.appendChild(option);
-        }
-      }
-
-      if (document.getElementById('majors') !== null) {
-        for (let major of majors) {
-          let option = document.createElement('option');
-          option.text = major['major'];
-          option.value = major['major'];
-          let select = document.getElementById('majors');
-          select.appendChild(option);
-        }
-      }
-    }, 0);
     //setting user specific initial values
     formInitialValues['id'] = user?.id || '';
     formInitialValues['preferredEmail'] = user?.preferredEmail || '';


### PR DESCRIPTION
Add schools and majors options to hack portal config object directly rathert han adding them by query selecting for the DOM element the config is loaded into on register.tsx

fix #226